### PR TITLE
Replace PR with npm link for Theia package

### DIFF
--- a/hugo/content/_index.html
+++ b/hugo/content/_index.html
@@ -29,7 +29,7 @@ type: oct
         </div>
         <div class="content-card">
             <h2>IDE extensions</h2>
-            <p>Get the VS Code extension from <a href="https://open-vsx.org/extension/typefox/open-collaboration-tools">Open VSX</a> or the <a href="https://marketplace.visualstudio.com/items?itemName=typefox.open-collaboration-tools">VS Code Marketplace</a>. Eclipse Theia has a <a href="https://github.com/eclipse-theia/theia/pull/13309">built-in extension package</a> for the direct integration of Open Collaboration Tools.</p>
+            <p>Get the VS Code extension from <a href="https://open-vsx.org/extension/typefox/open-collaboration-tools">Open VSX</a> or the <a href="https://marketplace.visualstudio.com/items?itemName=typefox.open-collaboration-tools">VS Code Marketplace</a>. Eclipse Theia has a <a href="https://www.npmjs.com/package/@theia/collaboration">built-in extension package</a> for the direct integration of Open Collaboration Tools.</p>
         </div>
         <div class="content-card">
             <h2>Integrate in your web app</h2>


### PR DESCRIPTION
Now that the `@theia/collaboration` feature has been merged and released, we can replace the link to the npm package.